### PR TITLE
Implement "intelligent" breaking for records & objects.

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/oo.re
+++ b/formatTest/typeCheckedTests/expected_output/oo.re
@@ -116,24 +116,12 @@ let (>>) = (a, b) => a > b;
 
 let bigger = 3 >> 2;
 
-type typeDefForClosedObj = {
-  .
-  x: int,
-  y: int
-};
+type typeDefForClosedObj = {. x: int, y: int};
 
 type typeDefForOpenObj('a) =
-  {
-    ..
-    x: int,
-    y: int
-  } as 'a;
+  {.. x: int, y: int} as 'a;
 
-let anonClosedObject: {
-  .
-  x: int,
-  y: int
-} = {
+let anonClosedObject: {. x: int, y: int} = {
   pub x = 0;
   pub y = 0
 };
@@ -147,11 +135,7 @@ let xs: list({. x: int}) = [
 
 let constrainedAndCoerced = (
   [anonClosedObject, anonClosedObject]:
-    list({
-      .
-      x: int,
-      y: int
-    }) :>
+    list({. x: int, y: int}) :>
     list({. x: int})
 );
 
@@ -170,23 +154,11 @@ let coercedReturn = {
 };
 
 let acceptsOpenAnonObjAsArg =
-    (
-      o: {
-        ..
-        x: int,
-        y: int
-      }
-    ) =>
+    (o: {.. x: int, y: int}) =>
   o#x + o#y;
 
 let acceptsClosedAnonObjAsArg =
-    (
-      o: {
-        .
-        x: int,
-        y: int
-      }
-    ) =>
+    (o: {. x: int, y: int}) =>
   o#x + o#y;
 
 let res =

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -1,7 +1,4 @@
-type point = {
-  x: int,
-  y: int
-};
+type point = {x: int, y: int};
 
 let id = x => x;
 

--- a/formatTest/typeCheckedTests/expected_output/sequences.re
+++ b/formatTest/typeCheckedTests/expected_output/sequences.re
@@ -48,7 +48,9 @@ while (false) {
   print_string("test");
 };
 
-type myRecord = {number: int};
+type myRecord = {
+  number: int
+};
 
 let x = {number: 20};
 
@@ -70,11 +72,7 @@ let thisIsASequenceNotPunedRecord = number;
 
 let fourty = 20 + thisIsASequenceNotPunedRecord;
 
-type recordType = {
-  a: int,
-  b: int,
-  c: int
-};
+type recordType = {a: int, b: int, c: int};
 
 let a = 0;
 
@@ -83,11 +81,23 @@ let b = 0;
 let c = 0;
 
 /* All of these will be printed as punned because they have more than one field. */
-let firstFieldPunned = {a, b, c};
+let firstFieldPunned = {
+  a,
+  b,
+  c
+};
 
-let sndFieldPunned = {a, b, c};
+let sndFieldPunned = {
+  a,
+  b,
+  c
+};
 
-let thirdFieldPunned = {a, b, c};
+let thirdFieldPunned = {
+  a,
+  b,
+  c
+};
 
 let singlePunAcceptedIfExtended = {
   ...firstFieldPunned,

--- a/formatTest/unit_tests/expected_output/basicStructures.re
+++ b/formatTest/unit_tests/expected_output/basicStructures.re
@@ -701,16 +701,9 @@ type state = unit;
 
 type component = {props};
 
-type component2 = {
-  props,
-  state,
-  updater: unit
-};
+type component2 = {props, state, updater: unit};
 
-type component3 = {
-  props: M.props,
-  state
-};
+type component3 = {props: M.props, state};
 
 type mutableComponent = {mutable props};
 

--- a/formatTest/unit_tests/expected_output/features403.re
+++ b/formatTest/unit_tests/expected_output/features403.re
@@ -12,10 +12,7 @@ type nonrec u('a) =
 
 type expr('a) =
   | Val{value: 'a} : expr('a)
-  | Add{
-      left: expr(int),
-      right: expr(int)
-    }
+  | Add{left: expr(int), right: expr(int)}
     : expr(int)
   | Is0{test: expr(int)} : expr(bool)
   | If{

--- a/formatTest/unit_tests/expected_output/location.re
+++ b/formatTest/unit_tests/expected_output/location.re
@@ -1,0 +1,95 @@
+/* should not break */
+type point = {x: int, y: int};
+
+type point = {. "x": int, "y": int};
+
+type point = {.. "x": int, "y": int};
+
+let p = {x: 1, y: 1};
+
+let p = {"x": 1, "y": 1};
+
+/* should break */
+type point = {
+  x: int,
+  y: int
+};
+
+type point = {
+  .
+  "x": int,
+  "y": int
+};
+
+let p = {
+  x: 1,
+  y: 1
+};
+
+let p = {
+  "x": 1,
+  "y": 1
+};
+
+type point = {
+  x: int,
+  y: int
+};
+
+type point = {
+  .
+  "x": int,
+  "y": int
+};
+
+let p = {
+  x: 1,
+  y: 1
+};
+
+let p = {
+  "x": 1,
+  "y": 1
+};
+
+type point = {
+  x: int,
+  y: int
+};
+
+type point = {
+  .
+  "x": int,
+  "y": int
+};
+
+let p = {
+  x: 1,
+  y: 1
+};
+
+let p = {
+  "x": 1,
+  "y": 1
+};
+
+type point = {
+  x: int,
+  y: int
+};
+
+type point = {
+  .
+  "x": int,
+  "y": int
+};
+
+let p = {
+  x: 1,
+  y: 1
+};
+
+let p = {
+  "x": 1,
+  "y": 1
+};

--- a/formatTest/unit_tests/expected_output/modules.re
+++ b/formatTest/unit_tests/expected_output/modules.re
@@ -491,7 +491,9 @@ include
       type thing = blahblahblah;
       type state = unit;
       let getInitialState = (_) => ();
-      let myValue = {recordField: "hello"};
+      let myValue = {
+        recordField: "hello"
+      };
     }
   );
 

--- a/formatTest/unit_tests/expected_output/object.re
+++ b/formatTest/unit_tests/expected_output/object.re
@@ -19,17 +19,9 @@ let (<..>) = (a, b) => a + b;
 
 let five = 2 <..> 3;
 
-type closedObjSugar = {
-  .
-  "foo": bar,
-  "baz": int
-};
+type closedObjSugar = {. "foo": bar, "baz": int};
 
-type openObjSugar = {
-  ..
-  "x": int,
-  "y": int
-};
+type openObjSugar = {.. "x": int, "y": int};
 
 type x = Js.t({.});
 

--- a/formatTest/unit_tests/expected_output/syntax.re
+++ b/formatTest/unit_tests/expected_output/syntax.re
@@ -264,18 +264,14 @@ let desiredFormattingForWrappedSugarReturnOnNewLine =
    let rec f : 't1 't2. 't1 * 't2 list -> 't1 =
      fun (type t1) (type t2) -> (... : t1 * t2 list -> t1)
  */
-type point = {
-  x: int,
-  y: int
-};
+type point = {x: int, y: int};
 
-type point3D = {
-  x: int,
-  y: int,
-  z: int
-};
+type point3D = {x: int, y: int, z: int};
 
-let point2D = {x: 20, y: 30};
+let point2D = {
+  x: 20,
+  y: 30
+};
 
 let point3D: point3D = {
   x: 10,
@@ -328,10 +324,7 @@ let res3 =
     )
   );
 
-type person = {
-  age: int,
-  name: string
-};
+type person = {age: int, name: string};
 
 type hiredPerson = {
   age: string,
@@ -678,18 +671,12 @@ let myFunc = (a: int, b: int) : point => {
 
 type myThing = (int, int);
 
-type stillARecord = {
-  name: string,
-  age: int
-};
+type stillARecord = {name: string, age: int};
 
 /* Rebase latest OCaml to get the following: And fixup
    `generalized_constructor_arguments` according to master. */
 /* type ('a, 'b) myOtherThing = Leaf {first:'a, second: 'b} | Null; */
-type branch('a, 'b) = {
-  first: 'a,
-  second: 'b
-};
+type branch('a, 'b) = {first: 'a, second: 'b};
 
 type myOtherThing('a, 'b) =
   | Leaf(branch('a, 'b))

--- a/formatTest/unit_tests/expected_output/variants.re
+++ b/formatTest/unit_tests/expected_output/variants.re
@@ -229,10 +229,7 @@ type twoCurriedConstructorsPolyMorphic('a) =
   | TwoCombos(combination('a), combination('a));
 
 /* Matching records */
-type pointRecord = {
-  x: int,
-  y: int
-};
+type pointRecord = {x: int, y: int};
 
 type alsoHasARecord =
   | Blah

--- a/formatTest/unit_tests/expected_output/wrappingTest.re
+++ b/formatTest/unit_tests/expected_output/wrappingTest.re
@@ -2147,7 +2147,9 @@ let myFunc = (~firstArg, ~another, ~fl) => {
   nameBlah: 10
 };
 
-type inputEchoRecord('a) = {inputIs: 'a};
+type inputEchoRecord('a) = {
+  inputIs: 'a
+};
 
 let df_locallyAbstractFunc =
     (type a, type b, input: a) => {
@@ -2174,7 +2176,9 @@ let df_locallyAbstractFuncNotSugared =
  */
 let df_locallyAbstractFuncAnnotated:
   type a. (a, a) => inputEchoRecord(a) =
-  (input: a, input: a) => {inputIs: input};
+  (input: a, input: a) => {
+    inputIs: input
+  };
 
 /**
  * The following is automatically expanded at the parser level into:
@@ -2294,10 +2298,7 @@ type doubleEqualsRecord =
 
 type doubleEqualsDoublePrivateRecord =
   myRecordWithReallyLongName =
-    pri {
-      xx: int,
-      yy: int
-    };
+    pri {xx: int, yy: int};
 
 type someConstructor =
   | SomeConstructorHi(int, int);

--- a/formatTest/unit_tests/input/location.re
+++ b/formatTest/unit_tests/input/location.re
@@ -1,0 +1,68 @@
+/* should not break */
+type point = {x: int, y: int};
+
+type point = {. "x": int, "y": int};
+
+type point = {.. "x": int, "y": int};
+
+let p = {x: 1, y: 1};
+
+let p = {"x": 1, "y": 1};
+
+/* should break */
+type point = {x: int, y: int
+};
+
+type point = {. "x": int, "y": int
+};
+
+let p = {x: 1, y: 1
+};
+
+let p = {"x": 1, "y": 1
+};
+
+type point = {
+  x: int, y: int};
+
+type point = {.
+  "x": int, "y": int};
+
+let p = {
+  x: 1, y: 1};
+
+let p = {
+  "x": 1, "y": 1};
+
+type point = {x: int,
+  y: int};
+
+type point = {. "x": int,
+  "y": int};
+
+let p = {x: 1,
+  y: 1};
+
+let p = {"x": 1,
+  "y": 1};
+
+type point = {
+  x: int,
+  y: int
+};
+
+type point = {
+  .
+  "x": int,
+  "y": int
+};
+
+let p = {
+  x: 1,
+  y: 1
+};
+
+let p = {
+  "x": 1,
+  "y": 1
+};

--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -62,3 +62,7 @@ let funAppCallbackExceedsWidth ~printWidth ~args ~funExpr () =
     end
   in
   aux (printWidth - funLen) args
+
+(* Determines if the start & end position of Location are on the same line *)
+let staysOnOneLine ({loc_start; loc_end} : Location.t) =
+  loc_start.pos_lnum == loc_end.pos_lnum


### PR DESCRIPTION
Fixes https://github.com/facebook/reason/issues/1620 https://github.com/facebook/reason/issues/1207
The idea is that a line break in input should signify an intent to format a record/object with line breaks.  Refmt "relaxes" its hard coded rules in favour of checking the input for possible breaks. Since the start & begin location are part of the ast, we simply have to check if the line height of start & end loc are the same. If they are, then everything was on one line.

This has the benefit that `type point = {x: int, y: int}`, can be printed one line if desired.

On the other hand:
```reason
type point = {
    x: int, y: int};

type point = {x: int,
  y: int};

type point = {x: int, y: int
};
```
Since the structures above have been put on multiple lines,
everything will be formatted as:

```reason
type point = {
  x: int,
  y: int
};
```
This behaviour is the same as in Prettier.