### PR TITLE
Added error message for string quotes problem

### DIFF
--- a/src/reason-parser/reason_parser.messages.checked-in
+++ b/src/reason-parser/reason_parser.messages.checked-in
@@ -35630,7 +35630,7 @@ implementation: STRING LPAREN WITH
 ## LPAREN 
 ##
 
-<YOUR SYNTAX ERROR MESSAGE HERE>
+You probably used the wrong type of quotes. For String use " instead of '
 
 implementation: SWITCH PERCENT AND WHILE 
 ##


### PR DESCRIPTION
Hi,

In the following code:
```
let component = ReasonReact.statelessComponent("App");

let make = _children => {
  ...component,
  render: _self =>
    <div>
      <input name="search" />
      <button> (ReasonReact.string('Search')) </button>
    </div>,
};
```
in VS code it shows an unknown syntax error. The error is that `(ReasonReact.string('Search')) ` should be `(ReasonReact.string("Search")) `

By following the link in the description https://github.com/facebook/reason/blob/master/src/README.md#add-a-menhir-error-message was created this PR.