### PR TITLE
Make the ppx's driver aware

### DIFF
--- a/miscTests/jsxPpxTest.sh
+++ b/miscTests/jsxPpxTest.sh
@@ -28,7 +28,7 @@ do
     # for each test, we're gonna use ocamlc and the ppx to dump the post-ppx ocaml
     # file somewhere
 
-    ocamlc -dsource -ppx "./_build/install/default/bin/reactjs_jsx_ppx_${version}" \
+    ocamlc -dsource -ppx "./_build/default/.ppx/jbuild/reason.reactjs_jsx_ppx_${version}/ppx.exe --as-ppx" \
       -pp "./_build/install/default/bin/refmt --print binary" -impl $test \
       2> $tempFile
 

--- a/src/ppx/jbuild
+++ b/src/ppx/jbuild
@@ -1,8 +1,22 @@
 (jbuild_version 1)
 
-(executables
- ((names (ppx_react reactjs_jsx_ppx_v2 reactjs_jsx_ppx_v3))
-  (public_names (ppx_react reactjs_jsx_ppx_v2 reactjs_jsx_ppx_v3))
-  (package reason)
-  (libraries
-   (reason ocaml-migrate-parsetree ))))
+(library
+ ((name ppx_react)
+  (public_name reason.ppx_react)
+  (kind ppx_rewriter)
+  (modules ppx_react)
+  (libraries (reason ocaml-migrate-parsetree))))
+
+(library
+ ((name reactjs_jsx_ppx_v2)
+  (public_name reason.reactjs_jsx_ppx_v2)
+  (kind ppx_rewriter)
+  (modules reactjs_jsx_ppx_v2)
+  (libraries (reason ocaml-migrate-parsetree))))
+
+(library
+ ((name reactjs_jsx_ppx_v3)
+  (public_name reason.reactjs_jsx_ppx_v3)
+  (kind ppx_rewriter)
+  (modules reactjs_jsx_ppx_v3)
+  (libraries (reason ocaml-migrate-parsetree))))

--- a/src/ppx/jbuild
+++ b/src/ppx/jbuild
@@ -20,3 +20,11 @@
   (kind ppx_rewriter)
   (modules reactjs_jsx_ppx_v3)
   (libraries (reason ocaml-migrate-parsetree))))
+
+;; compatibility for those that use -ppx manually
+(executable
+ ((name ppx_react_compat)
+  (public_name ppx_react)
+  (modules ppx_react_compat)
+  (package reason)
+  (libraries (reason ocaml-migrate-parsetree ppx_react))))

--- a/src/ppx/ppx_react.ml
+++ b/src/ppx/ppx_react.ml
@@ -12,7 +12,6 @@ let lid txt =
 let str txt = { txt; loc = Location.none }
 
 let expandReactMacro =
-  Reason_toolchain.To_current.copy_mapper
   {
     default_mapper with
     structure = (fun mapper structure  ->
@@ -92,5 +91,6 @@ let expandReactMacro =
      | _ -> structure)
   }
 
-let _ = Compiler_libs.Ast_mapper.register "editor.rehydrate"
-    (fun _argv -> expandReactMacro)
+let () =
+  Driver.register ~name:"editor.rehydrate"
+    Versions.ocaml_404 (fun _config _cookies -> expandReactMacro)

--- a/src/ppx/ppx_react_compat.ml
+++ b/src/ppx/ppx_react_compat.ml
@@ -1,0 +1,3 @@
+module P = Ppx_react (* make sure we link this module *)
+
+let () = Migrate_parsetree_driver.run_as_ppx_rewriter ()

--- a/src/ppx/reactjs_jsx_ppx_v2.ml
+++ b/src/ppx/reactjs_jsx_ppx_v2.ml
@@ -38,7 +38,6 @@
 (* #if defined BS_NO_COMPILER_PATCH then *)
 open Migrate_parsetree
 open Ast_404
-module To_current = Convert(OCaml_404)(OCaml_current)
 
 let nolabel = Ast_404.Asttypes.Nolabel
 let labelled str = Ast_404.Asttypes.Labelled str
@@ -305,7 +304,7 @@ let jsxMapper () =
        | e -> default_mapper.expr mapper e) in
 
 (* #if defined BS_NO_COMPILER_PATCH then *)
-  To_current.copy_mapper { default_mapper with structure; expr }
+  { default_mapper with structure; expr }
 (* #else *)
   (* { default_mapper with structure; expr } *)
 (* #end *)
@@ -379,7 +378,9 @@ let jsxMapper () =
                   (* |])) *)
 (* let () = make_ppx "jsxv2" *)
 (* #elif defined BS_NO_COMPILER_PATCH then *)
-let () = Compiler_libs.Ast_mapper.register "JSX" (fun _argv -> jsxMapper ())
+let () =
+  Driver.register ~name:"JSX"
+    Versions.ocaml_404 (fun _config _cookies -> jsxMapper ())
 (* #else *)
 (* let () = Ast_mapper.register "JSX" (fun _argv -> jsxMapper ()) *)
 (* #end *)

--- a/src/ppx/reactjs_jsx_ppx_v3.ml
+++ b/src/ppx/reactjs_jsx_ppx_v3.ml
@@ -38,7 +38,6 @@
 (* #if defined BS_NO_COMPILER_PATCH then *)
 open Migrate_parsetree
 open Ast_404
-module To_current = Convert(OCaml_404)(OCaml_current)
 
 let nolabel = Ast_404.Asttypes.Nolabel
 let labelled str = Ast_404.Asttypes.Labelled str
@@ -304,13 +303,15 @@ let jsxMapper () =
        | e -> default_mapper.expr mapper e) in
 
 (* #if defined BS_NO_COMPILER_PATCH then *)
-  To_current.copy_mapper { default_mapper with structure; expr }
+  { default_mapper with structure; expr }
 (* #else *)
   (* { default_mapper with structure; expr } *)
 (* #end *)
 
 (* #if defined BS_NO_COMPILER_PATCH then *)
-let () = Compiler_libs.Ast_mapper.register "JSX" (fun _argv -> jsxMapper ())
+let () =
+  Driver.register ~name:"JSX"
+    Versions.ocaml_404 (fun _config _cookies -> jsxMapper ())
 (* #else *)
 (* let () = Ast_mapper.register "JSX" (fun _argv -> jsxMapper ()) *)
 (* #end *)


### PR DESCRIPTION
The current ppx's only act as classical ppx's which make them unusable for all
dune users. The situation is easily fixed by defining the rewriters using dune's
ppx_rewriter kind.

This will create a ppx library that will work when linked into a driver and a
standalone ppx.exe rewriter for use in classical ppx. findlib's tags are used to
distinguish the 2 cases (see the ppx_driver tag).

The only "problem" with this transition is that every ppx needs a valid library
name. We could maintain the old names, but then we'd have to introduce toplevel
packages for them. Instead, we just put these ppx rewriters under the reason
pacakge.

Signed-off-by: Rudi Grinberg <rudi.grinberg@gmail.com>