### PR TITLE
Store refmt as a CircleCI artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,6 +167,9 @@ jobs:
           <<: *esy_post_build_cache_key
           paths:
             - ~/.esy
+      - store_artifacts:
+          path: _esy/default/build/default/src/refmt/refmt_impl.exe
+          destination: refmt.exe
 
 workflows:
   version: 2


### PR DESCRIPTION
This commit is for being able to download latest `refmt` on CI without installing and compiling OCaml and the `reason` package, as I mentioned in https://github.com/Schniz/fnm/pull/151