### PR TITLE
Revert "Better handling of longidents in JSX (#2541)"

### DIFF
--- a/formatTest/typeCheckedTests/expected_output/jsx.re
+++ b/formatTest/typeCheckedTests/expected_output/jsx.re
@@ -370,10 +370,12 @@ let asd =
   [@foo] <One test=true foo=2> "a" "b" </One>;
 let asd2 =
   [@foo]
-  <One.createElementobvioustypo test=false>
-    "a"
-    "b"
-  </One.createElementobvioustypo>;
+  [@JSX]
+  One.createElementobvioustypo(
+    ~test=false,
+    ~children=["a", "b"],
+    (),
+  );
 
 let span =
     (~test: bool, ~foo: int, ~children, ()) => 1;

--- a/formatTest/unit_tests/expected_output/jsx.re
+++ b/formatTest/unit_tests/expected_output/jsx.re
@@ -721,7 +721,3 @@ let v =
     four={msg##errorText}
   />
 </ActionButton>;
-
-<Foo.bar />;
-
-<Foo.Bar.baz arg="hello" />;

--- a/formatTest/unit_tests/input/jsx.re
+++ b/formatTest/unit_tests/input/jsx.re
@@ -574,7 +574,3 @@ let v =
   }>
   <InactionText three={msg##prop} four={msg##errorText} />
 </ActionButton>;
-
-<Foo.bar />;
-
-<Foo.Bar.baz arg="hello" />;

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -921,18 +921,17 @@ let rewriteFunctorApp module_name elt loc =
   else
     mkexp ~loc (Pexp_ident {txt=Ldot (module_name, elt); loc})
 
-let jsx_component lid attrs children loc =
-  let is_module_name = function
-    | Lident s
-    | Ldot (_, s) ->
-      (* s will be non-empty so the 0th access is fine. Modules can't start with underscore *)
-       String.get s 0 != '_' && s = String.capitalize_ascii s
-    | Lapply (_, _) -> true
-  in
-  let element_fn = if is_module_name lid.txt then
-      rewriteFunctorApp lid.txt "createElement" lid.loc
-    else
-      mkexp ~loc:lid.loc (Pexp_ident lid)
+let jsx_component module_name attrs children loc =
+  let rec getFirstPart = function
+    | Lident fp -> fp
+    | Ldot (fp, _) -> getFirstPart fp
+    | Lapply (fp, _) -> getFirstPart fp in
+  let firstPart = getFirstPart module_name.txt in
+  let element_fn = if String.get firstPart 0 != '_' && firstPart = String.capitalize_ascii firstPart then
+    (* firstPart will be non-empty so the 0th access is fine. Modules can't start with underscore *)
+    rewriteFunctorApp module_name.txt "createElement" module_name.loc
+  else
+    mkexp ~loc:module_name.loc (Pexp_ident(mkloc (Lident firstPart) module_name.loc))
   in
   let body = mkexp(Pexp_apply(element_fn, attrs @ children)) ~loc in
   let attribute = {

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3496,13 +3496,12 @@ let printer = object(self:'self)
       | _ :: rest -> hasSingleNonLabelledUnitAndIsAtTheEnd rest
       in
       if hasLabelledChildrenLiteral && hasSingleNonLabelledUnitAndIsAtTheEnd l then
-        match loc.txt with
-        | Ldot (moduleLid, "createElement") ->
-          Some (self#formatJSXComponent
-                  (String.concat "." (Longident.flatten moduleLid)) l)
-        | lid ->
-          Some (self#formatJSXComponent
-                  (String.concat "." (Longident.flatten lid)) l)
+        let moduleNameList = List.rev (List.tl (List.rev (Longident.flatten loc.txt))) in
+        if moduleNameList != [] then
+          if Longident.last loc.txt = "createElement" then
+            Some (self#formatJSXComponent (String.concat "." moduleNameList) l)
+          else None
+        else Some (self#formatJSXComponent (Longident.last loc.txt) l)
       else None
     )
     | (Pexp_apply (


### PR DESCRIPTION
This reverts commit 35896458c960e582965e5f977705d17618578d67.

The PR breaks the following example in the JSX PPX.

```reason
module Internal = {
  [@react.component]
  let header = () => <div />;
};

[@react.component]
let make = () => <div> <Internal.header /> </div>;
```