### PR TITLE
Fix version constraint OCaml 4.12

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "version": "3.7.0",
   "dependencies": {
-    "ocaml": " >= 4.2.0 < 4.12.0",
+    "ocaml": " >= 4.2.0 < 4.13.0",
     "@opam/fix": "*",
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",

--- a/reason.json
+++ b/reason.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/facebook/reason.git"
   },
   "dependencies": {
-    "ocaml": " >= 4.2.0 < 4.12.0",
+    "ocaml": " >= 4.2.0 < 4.13.0",
     "@opam/fix": "*",
     "@opam/ocamlfind": "*",
     "@opam/menhir": " >= 20170418.0.0",


### PR DESCRIPTION
This fix the version constraint in npm / esy. I've been using Reason and OCaml 4.12 for a while now, so this is pretty stable.