### PR TITLE
[refmt] Add env variable to configure --print-width

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ test-once-installed: clean-tests
 	./miscTests/rtopIntegrationTest.sh
 	./miscTests/backportSyntaxTests.sh
 	cd formatTest; ./test.sh
+	dune runtest
 
 .PHONY: coverage
 coverage:

--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
-(lang dune 2.3)
-
+(lang dune 2.7)
 (name reason)
 
 (using menhir 2.0)
+(cram enable)

--- a/refmt_test/README.md
+++ b/refmt_test/README.md
@@ -1,3 +1,21 @@
 # refmt cram test suite
 
-This folder contains the cram tests from dune, more information on how they work and how to create them in [here](https://discuss.ocaml.org/t/cram-tests-on-short-notice/6256)
+This folder contains cram tests from dune.
+
+## Run them locally use
+
+```bash
+esy dune runtest
+# or in watch mode
+esy dune runtest -w
+```
+
+## Update snapshot
+
+The usual workflow is to run the test once, let it fail and then update the snapshot with the output you expect with promotion:
+
+```bash
+esy dune promote
+```
+
+More information on how they work and how to create them in [dune's documentation](https://dune.readthedocs.io/en/stable/tests.html#cram-tests)

--- a/refmt_test/README.md
+++ b/refmt_test/README.md
@@ -1,0 +1,3 @@
+# refmt cram test suite
+
+This folder contains the cram tests from dune, more information on how they work and how to create them in [here](https://discuss.ocaml.org/t/cram-tests-on-short-notice/6256)

--- a/refmt_test/dune
+++ b/refmt_test/dune
@@ -1,0 +1,2 @@
+(cram
+ (deps ./run-refmt.sh))

--- a/refmt_test/print-width-env.t
+++ b/refmt_test/print-width-env.t
@@ -1,0 +1,18 @@
+Create a file with a long line
+  $ cat >test.re <<EOF
+  > let initialState = uiStateFromValidated(~ownership=RemoteData.NotAsked, ~limits=initialLimits, SiteAuditSettings.default);
+  > EOF
+
+Set the print width to 120 characters via env "REFMT_PRINT_WIDTH"
+  $ REFMT_PRINT_WIDTH=120 ./run-refmt.sh test.re
+  let initialState =
+    uiStateFromValidated(~ownership=RemoteData.NotAsked, ~limits=initialLimits, SiteAuditSettings.default);
+
+Set the print width to 80 characters via env "REFMT_PRINT_WIDTH"
+  $ REFMT_PRINT_WIDTH=80 ./run-refmt.sh test.re
+  let initialState =
+    uiStateFromValidated(
+      ~ownership=RemoteData.NotAsked,
+      ~limits=initialLimits,
+      SiteAuditSettings.default,
+    );

--- a/refmt_test/run-refmt.sh
+++ b/refmt_test/run-refmt.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script allows to run refmt in a way that is compatible with both CI and development.
+# CI works with opam and expects refmt to be available in $PATH
+# while development works with esy and you want to always run refmt from src/refmt
+
+set -e
+
+# $CI is set by CircleCI
+# TF_BUILD is set by Azure Pipelines
+if [[ -n $CI || -n $TF_BUILD ]]; then
+  refmt "$@"
+else
+  esy x refmt "$@"
+fi

--- a/src/refmt/refmt_args.ml
+++ b/src/refmt/refmt_args.ml
@@ -43,7 +43,8 @@ let print =
 let print_width =
   let docv = "COLS" in
   let doc = "wrapping width for printing the AST" in
-  Arg.(value & opt (int) (80) & info ["w"; "print-width"] ~docv ~doc)
+  let env = Arg.env_var "REFMT_PRINT_WIDTH" ~doc in
+  Arg.(value & opt (int) (80) & info ["w"; "print-width"] ~docv ~doc ~env)
 
 let heuristics_file =
   let doc =


### PR DESCRIPTION
The workaround is to have an env variable to set the wrapping width for printing. It should unblock https://github.com/reasonml/reason/issues/2567 and delay the discussion about the need for a config file.

This unblocks editor integrations to configure it however they want it.

```
$ echo "let initialState = uiStateFromValidated(~ownership=RemoteData.NotAsked, ~limits=initialLimits, SiteAuditSettings.default);" | REFMT_PRINT_WIDTH=80 esy x refmt
let initialState =
  uiStateFromValidated(
    ~ownership=RemoteData.NotAsked,
    ~limits=initialLimits,
    SiteAuditSettings.default,
  );

$ echo "let initialState = uiStateFromValidated(~ownership=RemoteData.NotAsked, ~limits=initialLimits, SiteAuditSettings.default);" | REFMT_PRINT_WIDTH=120 esy x refmt
let initialState =
  uiStateFromValidated(~ownership=RemoteData.NotAsked, ~limits=initialLimits, SiteAuditSettings.default);
```

---

This PR also adds cram tests, which tests refmt end to end, and are a little nicer than our test.sh: 

- cram tests are fast
- cram makes it easy to generate snapshots (something we had to manually do) and diff snapshots for us with meaningful error messages
- Much easier and less error prone to add new tests

