### PR TITLE
Fix ppat_constraint case

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 3.9
+
+- Fix missing patterns around contraint pattern (a pattern with a type annotation).
+
 ## 3.8.2
 
 - Fix magic numbers for OCaml 5.0 (@anmonteiro) [#2671](https://github.com/reasonml/reason/pull/2671)

--- a/formatTest/typeCheckedTests/expected_output/patternMatching.re
+++ b/formatTest/typeCheckedTests/expected_output/patternMatching.re
@@ -287,3 +287,26 @@ type aOrB =
   | B(int);
 let (nestedAnnotation: int): int = 0;
 let (A(i) | B(i)): aOrB = A(0);
+
+type test_foo =
+  | VariantType1
+  | VariantType2;
+
+let branch_with_variant_and_annotation =
+  fun
+  | (VariantType1: test_foo) => true
+  | VariantType2 => false;
+
+type intRange = {
+  from: option(string),
+  to_: option(string),
+};
+
+type optIntRange = option(intRange);
+
+let optIntRangeOfIntRange =
+  fun
+  | ({from: None, to_: None}: intRange) => (
+      None: optIntRange
+    )
+  | {from, to_} => Some({from, to_});

--- a/formatTest/typeCheckedTests/input/patternMatching.re
+++ b/formatTest/typeCheckedTests/input/patternMatching.re
@@ -242,3 +242,25 @@ switch (None) {
 type aOrB = A(int) | B(int);
 let ((nestedAnnotation: int) : int) = 0;
 let ((A(i) | B(i): aOrB)) = A(0);
+
+
+type test_foo = 
+  | VariantType1 
+  | VariantType2
+
+let branch_with_variant_and_annotation =
+  fun
+  | (VariantType1: test_foo) => true
+  | VariantType2 => false;
+
+type intRange = {
+  from: option(string),
+  to_: option(string)
+}  
+
+type optIntRange = option(intRange)
+
+let optIntRangeOfIntRange =
+  fun
+  | ({from: None, to_: None}: intRange) => (None: optIntRange)
+  | {from, to_} => Some({from, to_});

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7886,6 +7886,10 @@ let printer = object(self:'self)
         | [] -> []
         | hd::tl ->
           let formattedHd = self#pattern hd in
+          let formattedHd = match hd.ppat_desc with 
+          | Ppat_constraint _ -> formatPrecedence formattedHd
+          | _ -> formattedHd
+          in
           let formattedHd =
             if tl == [] then appendWhereAndArrow formattedHd else formattedHd
           in


### PR DESCRIPTION
Fixes issue [2636](https://github.com/reasonml/reason/issues/2636) where 

```
let branch_with_variant_and_annotation =
  fun
  | (VariantType1: test_foo) => true
  | VariantType2 => false;
```

is printed as

```
let branch_with_variant_and_annotation =
  fun
  | VariantType1: test_foo => true
  | VariantType2 => false;
```

and fails to compile.