### PR TITLE
Make sure win doesnt break when importing

### DIFF
--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -71,6 +71,8 @@ jobs:
 
       - name: Import dependencies
         if: steps.deps-cache.outputs.cache-hit == 'true'
+        # Don't crash the run if esy cache import fails - mostly happens on Windows
+        continue-on-error: true
         run: |
           esy import-dependencies _export
           rm -rf _export


### PR DESCRIPTION
Little hot fix to avoid breaking CI. Saw it in grain-lang: https://github.com/grain-lang/grain/blob/main/.github/workflows/ci.yml