### PR TITLE
Polyvariants printing similar to variants

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
   [#2773](https://github.com/reasonml/reason/pull/2773))
 - Wrap `let lazy patterns = ..` in parentheses (`let lazy(patterns) = ..`)
   (@anmonteiro, [#2774](https://github.com/reasonml/reason/pull/2774))
+- Print poly variants as normal variansts (@Sander Spies) [#2708](https://github.com/reasonml/reason/pull/2708)
 
 ## 3.12.0
 

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3118,7 +3118,10 @@ let printer = object(self:'self)
           let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
           let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
           let type_list = if tl != [] then node_list@[tag_list] else node_list in
-          let break = if List.length type_list > 1 then Layout.Always_rec else IfNeed in
+          let break = match type_list with
+            | _ :: _ :: _ -> Layout.Always_rec
+            | [] | _ :: [] -> IfNeed
+          in
           makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break type_list
         | Ptyp_class (li, []) -> makeList [atom "#"; self#longident_loc li]
         | Ptyp_class (li, l) ->

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3118,7 +3118,8 @@ let printer = object(self:'self)
           let ll = (List.map (fun t -> atom ("`" ^ t)) tl) in
           let tag_list = makeList ~postSpace:true ~break:IfNeed ((atom ">")::ll) in
           let type_list = if tl != [] then node_list@[tag_list] else node_list in
-          makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break:IfNeed type_list
+          let break = if List.length type_list > 1 then Layout.Always_rec else IfNeed in
+          makeList ~wrap:("[" ^ designator,"]") ~pad:(true, false) ~postSpace:true ~break type_list
         | Ptyp_class (li, []) -> makeList [atom "#"; self#longident_loc li]
         | Ptyp_class (li, l) ->
           label
@@ -7688,7 +7689,7 @@ let printer = object(self:'self)
       let loc_end = last.pstr_loc.loc_end in
       let items =
         groupAndPrint
-          ~xf:structure_item
+          ~xf:self#structure_item
           ~getLoc:(fun x -> x.pstr_loc)
           ~comments:self#comments
           structureItems

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -7689,7 +7689,7 @@ let printer = object(self:'self)
       let loc_end = last.pstr_loc.loc_end in
       let items =
         groupAndPrint
-          ~xf:self#structure_item
+          ~xf:structure_item
           ~getLoc:(fun x -> x.pstr_loc)
           ~comments:self#comments
           structureItems

--- a/test/4.10/type-jsx.t/run.t
+++ b/test/4.10/type-jsx.t/run.t
@@ -594,7 +594,7 @@ Print the formatted file
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
   File "formatted.re", line 463, characters 23-26:
-  460 |   <Optional1 required=?zzz />;
+  463 |   <Optional1 required=?zzz />;
                                ^^^
   Warning 43: the label required is not optional.
 

--- a/test/4.10/type-jsx.t/run.t
+++ b/test/4.10/type-jsx.t/run.t
@@ -368,7 +368,10 @@ Print the formatted file
   /**
    * Test no conflict with polymorphic variant types.
    */
-  type thisType = [ | `Foo | `Bar];
+  type thisType = [
+    | `Foo
+    | `Bar
+  ];
   type t('a) = [< thisType] as 'a;
   
   let asd =
@@ -590,7 +593,7 @@ Print the formatted file
 
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
-  File "formatted.re", line 460, characters 23-26:
+  File "formatted.re", line 463, characters 23-26:
   460 |   <Optional1 required=?zzz />;
                                ^^^
   Warning 43: the label required is not optional.

--- a/test/4.12/type-jsx.t/run.t
+++ b/test/4.12/type-jsx.t/run.t
@@ -368,7 +368,10 @@ Print the formatted file
   /**
    * Test no conflict with polymorphic variant types.
    */
-  type thisType = [ | `Foo | `Bar];
+  type thisType = [
+    | `Foo
+    | `Bar
+  ];
   type t('a) = [< thisType] as 'a;
   
   let asd =
@@ -590,8 +593,8 @@ Print the formatted file
 
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
-  File "formatted.re", line 460, characters 23-26:
-  460 |   <Optional1 required=?zzz />;
+  File "formatted.re", line 463, characters 23-26:
+  463 |   <Optional1 required=?zzz />;
                                ^^^
   Warning 43 [nonoptional-label]: the label required is not optional.
 

--- a/test/ocaml_identifiers.t/run.t
+++ b/test/ocaml_identifiers.t/run.t
@@ -80,7 +80,10 @@ Format OCaml identifiers file
   
   /* Polymorphic variants (probably ok as-is?) */
   module P = {
-    type t = [ | `pub_ | `method];
+    type t = [
+      | `pub_
+      | `method
+    ];
   
     let x = `method;
   


### PR DESCRIPTION
```
type align = [ | `Start | `End | `Center];
```
to 
```
type align = [ 
  | `Start
  | `End 
  | `Center
];
```

fixes https://github.com/reasonml/reason/issues/2706