### PR TITLE
chore: remove old BS_NO_COMPILER_PATCH flag

### DIFF
--- a/src/reason-parser/dune
+++ b/src/reason-parser/dune
@@ -74,46 +74,16 @@
    (run ../menhir-recover/main.exe reason_parser.cmly))))
 
 (rule
- (targets reason_oprint.ml)
- (deps reason_oprint.cppo.ml)
- (action
-  (run
-   %{bin:cppo}
-   -V
-   OCAML:%{ocaml_version}
-   -D
-   BS_NO_COMPILER_PATCH
-   %{deps}
-   -o
-   %{targets})))
-
-(rule
  (targets reason_syntax_util.ml)
  (deps reason_syntax_util.cppo.ml)
  (action
-  (run
-   %{bin:cppo}
-   -V
-   OCAML:%{ocaml_version}
-   -D
-   BS_NO_COMPILER_PATCH
-   %{deps}
-   -o
-   %{targets})))
+  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
 
 (rule
  (targets reason_syntax_util.mli)
  (deps reason_syntax_util.cppo.mli)
  (action
-  (run
-   %{bin:cppo}
-   -V
-   OCAML:%{ocaml_version}
-   -D
-   BS_NO_COMPILER_PATCH
-   %{deps}
-   -o
-   %{targets})))
+  (run %{bin:cppo} -V OCAML:%{ocaml_version} %{deps} -o %{targets})))
 
 (library
  (name reason)

--- a/src/reason-parser/reason_oprint.ml
+++ b/src/reason-parser/reason_oprint.ml
@@ -84,10 +84,8 @@
   patching the right parts, through the power of types(tm)
 *)
 
-#ifdef BS_NO_COMPILER_PATCH
 open Reason_omp
 open Ast_411
-#endif
 
 open Format
 open Outcometree
@@ -98,7 +96,6 @@ let cautious f ppf arg =
   try f ppf arg with
     Ellipsis -> fprintf ppf "..."
 
-#ifdef BS_NO_COMPILER_PATCH
 let rec print_ident ppf =
   function
     Oide_ident s -> pp_print_string ppf s.printed_name
@@ -106,15 +103,6 @@ let rec print_ident ppf =
       print_ident ppf id; pp_print_char ppf '.'; pp_print_string ppf s
   | Oide_apply (id1, id2) ->
       fprintf ppf "%a(%a)" print_ident id1 print_ident id2
-#else
-let rec print_ident ppf =
-  function
-    Oide_ident s -> !Oprint.out_ident ppf s
-  | Oide_dot (id, s) ->
-      print_ident ppf id; pp_print_char ppf '.'; !Oprint.out_ident ppf s
-  | Oide_apply (id1, id2) ->
-      fprintf ppf "%a(%a)" print_ident id1 print_ident id2
-#endif
 
 let parenthesized_ident name =
   (List.mem name ["or"; "mod"; "land"; "lor"; "lxor"; "lsl"; "lsr"; "asr"])

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -14,10 +14,8 @@
   patching the right parts, through the power of types(tm)
 *)
 
-#ifdef BS_NO_COMPILER_PATCH
 open Reason_omp
 open Ast_411
-#endif
 
 open Asttypes
 open Ast_mapper
@@ -154,8 +152,6 @@ let escape_string str =
 
 (* the stuff below contains side-effects and are not used by BuckleScript's
   vendored version of reason_syntax_util.ml. So we can neglect it *)
-
-#ifdef BS_NO_COMPILER_PATCH
 
 (*
     UTF-8 characters are encoded like this (most editors are UTF-8)
@@ -858,8 +854,6 @@ let explode_str str =
     if i < 0 then acc else loop (str.[i] :: acc) (i - 1)
   in
     loop [] (String.length str - 1)
-#endif
-
 
 module Clflags = struct
   include Clflags

--- a/src/reason-parser/reason_syntax_util.cppo.mli
+++ b/src/reason-parser/reason_syntax_util.cppo.mli
@@ -21,8 +21,6 @@ val escape_string : string -> string
 
 (* Everything below is used by reason repo but not the BuckleScript repo *)
 
-#ifdef BS_NO_COMPILER_PATCH
-
 val reason_to_ml_swap : string -> string
 
 module TrailingCommaMarker : sig val char : char val string : string end
@@ -95,7 +93,6 @@ val location_contains : Location.t -> Location.t -> bool
 val split_compiler_error : Location.error -> Location.t * string
 
 val explode_str : string -> char list
-#endif
 
 module Clflags : sig
   include module type of Clflags


### PR DESCRIPTION
Reason is not embedded into bucklescript anymore, this flag has been useless for a while.