### PR TITLE
fix(ci): pin the correct ocaml version for Esy

### DIFF
--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -28,8 +28,8 @@ jobs:
         ocaml-compiler:
           # Please keep the list in sync with the minimal version of OCaml in
           # esy.json, reason.esy/reason.opam and rtop.esy/rtop.opam.
+          - 4.08.x
           - 4.10.x
-          - 4.12.x
           - 4.14.x
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -28,7 +28,6 @@ jobs:
         ocaml-compiler:
           # Please keep the list in sync with the minimal version of OCaml in
           # esy.json, reason.esy/reason.opam and rtop.esy/rtop.opam.
-          - 4.08.x
           - 4.10.x
           - 4.14.x
 

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -67,7 +67,8 @@ jobs:
           restore-keys: esy-build-${{ matrix.os }}-
 
       - name: Instal OCaml ${{ matrix.ocaml-compiler }}
-        run: sed -i 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
+        run: |
+          sed -i 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
 
       - name: Install dependencies
         run: esy install

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -66,9 +66,9 @@ jobs:
           key: esy-build-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('esy.lock.json') }}
           restore-keys: esy-build-${{ matrix.os }}-
 
-      - name: Instal OCaml ${{ matrix.ocaml-compiler }}
+      - name: Install OCaml ${{ matrix.ocaml-compiler }}
         run: |
-          sed -i 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
+          sed -i.bak 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
 
       - name: Install dependencies
         run: esy install

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -26,15 +26,12 @@ jobs:
           - windows-latest
 
         ocaml-compiler:
-          # Please keep the list in sync with the minimal version of OCaml in
-          # esy.json, reason.esy/reason.opam and rtop.esy/rtop.opam.
-          - 4.10.x
           - 4.14.x
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:
@@ -63,10 +60,6 @@ jobs:
             _export
           key: esy-build-${{ matrix.os }}-${{ matrix.ocaml-compiler }}-${{ hashFiles('esy.lock.json') }}
           restore-keys: esy-build-${{ matrix.os }}-
-
-      - name: Install OCaml ${{ matrix.ocaml-compiler }}
-        run: |
-          sed -i.bak 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
 
       - name: Install dependencies
         run: esy install

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -28,7 +28,6 @@ jobs:
         ocaml-compiler:
           # Please keep the list in sync with the minimal version of OCaml in
           # esy.json, reason.esy/reason.opam and rtop.esy/rtop.opam.
-          - 4.06.x # We support 4.06 because is the one that is used in BuckleScript / ReScript v9
           - 4.10.x
           - 4.12.x
           - 4.14.x

--- a/.github/workflows/esy-ci.yml
+++ b/.github/workflows/esy-ci.yml
@@ -67,7 +67,7 @@ jobs:
           restore-keys: esy-build-${{ matrix.os }}-
 
       - name: Instal OCaml ${{ matrix.ocaml-compiler }}
-        run: esy add ocaml@${{ matrix.ocaml-compiler }}
+        run: sed -i 's/"ocaml": "~4.14.0"/"ocaml": "${{ matrix.ocaml-compiler }}"/g' esy.json
 
       - name: Install dependencies
         run: esy install

--- a/esy.json
+++ b/esy.json
@@ -16,7 +16,6 @@
     "ocaml": " >= 4.3.0 < 4.15.0"
   },
   "devDependencies": {
-    "@opam/ocaml-lsp-server": "1.15.1-4.14",
     "@opam/odoc": "*",
     "ocaml": "~4.14.0"
   },


### PR DESCRIPTION
In https://github.com/reasonml/reason/pull/2711 I noticed that esy is always running on 4.14.