### PR TITLE
Fix 2695: local open + let bindings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 - Add `\u{hex-escape}` syntax (@anmonteiro,
   [#2738](https://github.com/reasonml/reason/pull/2738))
+- Support local open and let bindings (@SanderSpies) [#2716](https://github.com/reasonml/reason/pull/2716)
 
 ## 3.11.0
 

--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -41,6 +41,9 @@ let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attrib
   | ({ attr_name = {txt="reason.preserve_braces"}; _} as attr) :: atTl ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with stylisticAttrs=attr::partition.stylisticAttrs}
+  | ({ attr_name = {txt="reason.openSyntaxNotation"}; _} as attr) :: atTl ->
+    let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
+    {partition with stylisticAttrs=attr::partition.stylisticAttrs}
   | atHd :: atTl ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     {partition with stdAttrs=atHd::partition.stdAttrs}
@@ -88,3 +91,9 @@ let maybe_remove_stylistic_attrs attrs should_preserve =
       | { attr_name = {txt="reason.raw_literal"}; _} -> true
       | _ -> false)
       attrs
+
+let is_open_notation_attr { attr_name = {txt}; _} =
+  txt = "reason.openSyntaxNotation"
+
+let has_open_notation_attr stylisticAttrs =
+  List.exists is_open_notation_attr stylisticAttrs

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3007,7 +3007,7 @@ parenthesized_expr:
 %inline bigarray_access:
   DOT LBRACE lseparated_nonempty_list(COMMA, expr) COMMA? RBRACE { $3 }
 
-expr_list_or_seq_expr: 
+expr_list_or_seq_expr:
   | expr_list { $1 }
   | seq_expr(SEMI) { [$1] };
 
@@ -3038,10 +3038,10 @@ expr_list_or_seq_expr:
   | E as_loc(POSTFIXOP)
     { mkexp(Pexp_apply(mkoperator $2, [Nolabel, $1])) }
   | od=open_dot_declaration DOT LPAREN expr_list_or_seq_expr RPAREN
-    { 
+    {
       let loc = mklocation $symbolstartpos $endpos in
-      let openSyntaxNotationAttribute = { 
-        attr_name = mkloc "reason.openSyntaxNotation" loc;
+      let openSyntaxNotationAttribute = {
+        Ppxlib.Parsetree.attr_name = mkloc "reason.openSyntaxNotation" loc;
         attr_payload = PStr [];
         attr_loc = Location.none
       } in

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -3038,7 +3038,14 @@ expr_list_or_seq_expr:
   | E as_loc(POSTFIXOP)
     { mkexp(Pexp_apply(mkoperator $2, [Nolabel, $1])) }
   | od=open_dot_declaration DOT LPAREN expr_list_or_seq_expr RPAREN
-    { mkexp(Pexp_open(od, may_tuple $startpos($3) $endpos($5) $4)) }
+    { 
+      let loc = mklocation $symbolstartpos $endpos in
+      let openSyntaxNotationAttribute = { 
+        attr_name = mkloc "reason.openSyntaxNotation" loc;
+        attr_payload = PStr [];
+        attr_loc = Location.none
+      } in
+      mkexp ~attrs:[openSyntaxNotationAttribute] (Pexp_open(od, may_tuple $startpos($3) $endpos($5) $4)) }
   | E DOT as_loc(label_longident)
     { mkexp(Pexp_field($1, $3)) }
   | od=open_dot_declaration DOT LBRACE RBRACE

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -4365,21 +4365,16 @@ let printer = object(self:'self)
      * Or ReasonReact.(<> {string("Test")} </>);
      *)
     | _ -> (
-      match parent with 
-      | Some (parent) -> (
-        if has_open_notation_attr parent.pexp_attributes then
-          makeList
-            ~break:IfNeed
-            ~inline:(true, false)
-            ~postSpace:true
-            ~wrap:("(",")")
-            ~sep:(SepFinal (";", ""))
-            (self#letList e)
-        else
-          makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
-      )
-      | None -> 
-        makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
+      match parent with
+      | Some parent when has_open_notation_attr parent.pexp_attributes ->
+        makeList
+          ~break:IfNeed
+          ~inline:(true, false)
+          ~postSpace:true
+          ~wrap:("(",")")
+          ~sep:(SepFinal (";", ""))
+          (self#letList e)
+      | Some _ | None -> makeList ~wrap:("(",")") ~break:IfNeed [self#unparseExpr e]
     )
 
   (*
@@ -5577,7 +5572,7 @@ let printer = object(self:'self)
                 pos_lnum = expr.pexp_loc.loc_start.pos_lnum
               }
             } in
-            processLetList ((loc, layout)::acc) e 
+            processLetList ((loc, layout)::acc) e
           )
         | ([], Pexp_letmodule (s, me, e)) ->
             let prefixText = "module" in
@@ -6474,7 +6469,7 @@ let printer = object(self:'self)
                     (self#moduleExpressionToFormattedApplicationItems me.popen_expr)
                     (atom (".")))
                   (self#formatNonSequencyExpression ~parent:x e))
-            else 
+            else
               Some  (makeLetSequence (self#letList e))
         | Pexp_send (e, s) ->
           let needparens = match e.pexp_desc with

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6442,20 +6442,16 @@ let printer = object(self:'self)
                 | _ -> Some (self#extension e)
           end
         | Pexp_open (me, e) ->
-            if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
               Some
                 (label
                   (label
                     (self#moduleExpressionToFormattedApplicationItems me.popen_expr)
                     (atom (".")))
-                  (self#formatNonSequencyExpression e))
-          else
-            Some
-                (label
-                  (label
-                    (self#moduleExpressionToFormattedApplicationItems me.popen_expr)
-                    (atom (".")))
-                  (makeLetSequence ~wrap:("(", ")") (self#letList e)))
+                  (
+                    if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
+                      self#formatNonSequencyExpression e
+                    else
+                      (makeLetSequence ~wrap:("(", ")") (self#letList e))))
         | Pexp_send (e, s) ->
           let needparens = match e.pexp_desc with
             | Pexp_apply (ee, _) ->

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6450,7 +6450,12 @@ let printer = object(self:'self)
                     (atom (".")))
                   (self#formatNonSequencyExpression e))
           else
-            Some (makeLetSequence (self#letList x))
+            Some
+                (label
+                  (label
+                    (self#moduleExpressionToFormattedApplicationItems me.popen_expr)
+                    (atom (".")))
+                  (makeLetSequence ~wrap:("(", ")") (self#letList e)))
         | Pexp_send (e, s) ->
           let needparens = match e.pexp_desc with
             | Pexp_apply (ee, _) ->

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6467,15 +6467,13 @@ let printer = object(self:'self)
                 | _ -> Some (self#extension e)
           end
         | Pexp_open (me, e) ->
-            if self#isSeriesOfOpensFollowedByNonSequencyExpression x then (              
+            if self#isSeriesOfOpensFollowedByNonSequencyExpression x then
               Some
                 (label
                   (label
                     (self#moduleExpressionToFormattedApplicationItems me.popen_expr)
                     (atom (".")))
-                  (
-                    self#formatNonSequencyExpression ~parent:x e
-                  )))
+                  (self#formatNonSequencyExpression ~parent:x e))
             else 
               Some  (makeLetSequence (self#letList e))
         | Pexp_send (e, s) ->

--- a/test/modules.t/input.re
+++ b/test/modules.t/input.re
@@ -502,6 +502,11 @@ module L = Lola1();
 module L2 = Lola2(Cat, Dog, Foo);
 
 let y = Promise.Ops.(
-  let* x = Js.Promise.resolve(42);
-  Js.Promise.resolve(x * 2);
+  open Foo.Bar;
+  let a = 2
+  Bar.(
+    let* x = Js.Promise.resolve(42);
+    let a = 1;
+    Js.Promise.resolve(x * 2)
+  )
 );

--- a/test/modules.t/input.re
+++ b/test/modules.t/input.re
@@ -500,3 +500,8 @@ module Lola2 = (C: Cat, D: Dog, L: Lion) => {
 module L = Lola1();
 
 module L2 = Lola2(Cat, Dog, Foo);
+
+let y = Promise.Ops.(
+  let* x = Js.Promise.resolve(42);
+  Js.Promise.resolve(x * 2);
+);

--- a/test/modules.t/run.t
+++ b/test/modules.t/run.t
@@ -668,7 +668,12 @@ Format modules
   
   let y =
     Promise.Ops.(
-      let* x = Js.Promise.resolve(42);
-      Js.Promise.resolve(x * 2);
+      open Foo.Bar;
+      let a = 2;
+      Bar.(
+        let* x = Js.Promise.resolve(42);
+        let a = 1;
+        Js.Promise.resolve(x * 2);
+      )
     );
 /* From http://stackoverflow.com/questions/1986374/  higher-order-type-constructors-and-functors-in-ocaml */

--- a/test/modules.t/run.t
+++ b/test/modules.t/run.t
@@ -666,9 +666,9 @@ Format modules
   
   module L2 = Lola2(Cat, Dog, Foo);
   
-  let y = {
-    open Promise.Ops;
-    let* x = Js.Promise.resolve(42);
-    Js.Promise.resolve(x * 2);
-  };
+  let y =
+    Promise.Ops.(
+      let* x = Js.Promise.resolve(42);
+      Js.Promise.resolve(x * 2);
+    );
 /* From http://stackoverflow.com/questions/1986374/  higher-order-type-constructors-and-functors-in-ocaml */

--- a/test/modules.t/run.t
+++ b/test/modules.t/run.t
@@ -665,4 +665,10 @@ Format modules
   module L = Lola1();
   
   module L2 = Lola2(Cat, Dog, Foo);
+  
+  let y = {
+    open Promise.Ops;
+    let* x = Js.Promise.resolve(42);
+    Js.Promise.resolve(x * 2);
+  };
 /* From http://stackoverflow.com/questions/1986374/  higher-order-type-constructors-and-functors-in-ocaml */


### PR DESCRIPTION
Solves #2695.

Makes it possible to use:

```
 let y = Promise.Ops.(
  let* x = Js.Promise.resolve(42);
  Js.Promise.resolve(x * 2);
);
```

Printing isn't perfect, but good enough for now. 