### PR TITLE
recognize `mel.obj` instead of `bs.obj`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1681154353,
-        "narHash": "sha256-MCJ5FHOlbfQRFwN0brqPbCunLEVw05D/3sRVoNVt2tI=",
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "f529f42792ade8e32c4be274af6b6d60857fbee7",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1686968282,
-        "narHash": "sha256-XDNUgEIvF4dxYYApEkQGkYXji0Cbjjvx673F9Z3c/Yk=",
+        "lastModified": 1689983586,
+        "narHash": "sha256-iXoptb2wkyXy1gQDKNFoal4KVEasgWFZAiSERqKgtq0=",
         "owner": "nix-ocaml",
         "repo": "nix-overlays",
-        "rev": "65c280960218799ca5fbad04d9b36e0224615e68",
+        "rev": "055362e6b820fa29ed59d779bbfa85869b1e9b23",
         "type": "github"
       },
       "original": {
@@ -56,17 +56,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1686953075,
-        "narHash": "sha256-wuyQEsKKW38bYzmkH51jrs9k+VtE0iWNLIyCUYapFDk=",
+        "lastModified": 1689951833,
+        "narHash": "sha256-wdpIgb5X0p85RRne74TeUOp9ti7a1k9KDSe4NzsaAGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a199713f336d12f8bbc37cdf72a46e08b5cb4797",
+        "rev": "ebf4e87429ce7faa51a86a36a7b2e615c8bcc735",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a199713f336d12f8bbc37cdf72a46e08b5cb4797",
+        "rev": "ebf4e87429ce7faa51a86a36a7b2e615c8bcc735",
         "type": "github"
       }
     },

--- a/src/reason-parser/reason_attributes.ml
+++ b/src/reason-parser/reason_attributes.ml
@@ -17,7 +17,7 @@ let rec partitionAttributes ?(partDoc=false) ?(allowUncurry=true) attrs : attrib
   match attrs with
   | [] ->
     {arityAttrs=[]; docAttrs=[]; stdAttrs=[]; jsxAttrs=[]; stylisticAttrs=[]; uncurried = false}
-  | ({ attr_name = {txt = "bs"}; attr_payload = PStr []; _ } as attr)::atTl ->
+  | ({ attr_name = {txt = ("u" | "bs")}; attr_payload = PStr []; _ } as attr)::atTl ->
     let partition = partitionAttributes ~partDoc ~allowUncurry atTl in
     if allowUncurry then
       {partition with uncurried = true}

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -2495,7 +2495,7 @@ mark_position_exp
   | LBRACE record_expr_with_string_keys RBRACE
     { let loc = mklocation $symbolstartpos $endpos in
       let (exten, fields) = $2 in
-      mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+      mkexp ~loc (Pexp_extension (mkloc ("mel.obj") loc,
              PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
     }
   (* Todo: Why is this not a simple_expr? *)
@@ -3062,7 +3062,7 @@ parenthesized_expr:
   | od=open_dot_declaration DOT LBRACE record_expr_with_string_keys RBRACE
     { let (exten, fields) = $4 in
       let loc = mklocation $symbolstartpos $endpos in
-      let rec_exp = mkexp ~loc (Pexp_extension (mkloc ("bs.obj") loc,
+      let rec_exp = mkexp ~loc (Pexp_extension (mkloc ("mel.obj") loc,
              PStr [mkstrexp (mkexp ~loc (Pexp_record(fields, exten))) []]))
       in
       mkexp(Pexp_open(od, rec_exp))

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -145,7 +145,7 @@ let make_floating_doc attr =
       {attr with attr_name = {attr_name with txt = "ocaml.text"}}
   | attr -> attr
 
-let uncurry_payload ?(name="bs") loc =
+let uncurry_payload ?(name="u") loc =
   { Ppxlib.Parsetree.attr_name = {loc; txt = name};
     attr_payload = PStr [];
     attr_loc = loc

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -3901,7 +3901,7 @@ let printer = object(self:'self)
          )} as e ->
           let args = PipeFirstTree.Args args in
           begin match pexp_attributes with
-          | [{ attr_name = {txt = "bs"}; attr_payload = PStr []}] ->
+          | [{ attr_name = {txt = "u" | "bs"}; attr_payload = PStr []}] ->
             flatten ((PipeFirstTree.ExpU arg2)::args::acc) arg1
           | [] ->
               (* the uncurried attribute might sit on the Pstr_eval

--- a/test/ocaml_identifiers.t/input.ml
+++ b/test/ocaml_identifiers.t/input.ml
@@ -85,7 +85,7 @@ let x = f ~method_:"GET"
 
 type marshalFields = < switch: string   >  Js.t
 
-let testMarshalFields = ([%bs.obj { switch = "switch" }] : marshalFields)
+let testMarshalFields = ([%mel.obj { switch = "switch" }] : marshalFields)
 
 (* Not an identifier test, but this is testing OCaml -> RE *)
 let x = List.map (fun y ->

--- a/test/uncurried.t/run.t
+++ b/test/uncurried.t/run.t
@@ -88,7 +88,7 @@ Format uncurried
     };
   
   class type _rect =
-    [@bs]
+    [@u]
     {
       [@bs.set]
       pub height: int;


### PR DESCRIPTION
We're moving from `%bs.obj` to `%mel.obj` in https://github.com/melange-re/melange/pull/663

- This change makes that possible in Reason as well
- BuckleScript is no longer; ReScript is not using Reason
- This change should be safe to ship (and release as part of the melange v2 releases)
