### PR TITLE
fix: outcome printer migration 5.2 -> 5.1 for labeled args

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   [#2738](https://github.com/reasonml/reason/pull/2738))
 - Support local open and let bindings (@SanderSpies) [#2716](https://github.com/reasonml/reason/pull/2716)
 - outcome printer: change the printing of `@bs.*` to `@mel.*` (@anmonteiro, [#2755](https://github.com/reasonml/reason/pull/2755))
+- Fix outcome printing of optional arguments on OCaml 5.2 (@anmonteiro, [#2753](https://github.com/reasonml/reason/pull/2753))
 
 ## 3.11.0
 

--- a/src/vendored-omp/src/migrate_parsetree_51_52_migrate.ml
+++ b/src/vendored-omp/src/migrate_parsetree_51_52_migrate.ml
@@ -1,6 +1,13 @@
 open Stdlib0
 module From = Ast_51
 module To = Ast_52
+
+let get_label lbl =
+  if lbl = "" then Ast_52.Asttypes.Nolabel
+  else if String.get lbl 0 = '?' then
+    Optional (String.sub lbl 1 @@ String.length lbl - 1)
+  else Labelled lbl
+
 let rec copy_out_type_extension :
   Ast_51.Outcometree.out_type_extension ->
     Ast_52.Outcometree.out_type_extension
@@ -170,7 +177,7 @@ and copy_out_class_type :
         ((copy_out_ident x0), (List.map copy_out_type x1))
   | Ast_51.Outcometree.Octy_arrow (x0, x1, x2) ->
       Ast_52.Outcometree.Octy_arrow
-        ((if x0 = "" then Nolabel else Labelled x0), (copy_out_type x1), (copy_out_class_type x2))
+        (get_label x0, (copy_out_type x1), (copy_out_class_type x2))
   | Ast_51.Outcometree.Octy_signature (x0, x1) ->
       Ast_52.Outcometree.Octy_signature
         ((Option.map copy_out_type x0),
@@ -218,7 +225,7 @@ and copy_out_type :
   | Ast_51.Outcometree.Otyp_open -> Ast_52.Outcometree.Otyp_open
   | Ast_51.Outcometree.Otyp_arrow (x0, x1, x2) ->
       Ast_52.Outcometree.Otyp_arrow
-        ((if x0 = "" then Nolabel else Labelled x0), (copy_out_type x1), (copy_out_type x2))
+        (get_label x0, (copy_out_type x1), (copy_out_type x2))
   | Ast_51.Outcometree.Otyp_class (x0, x1) ->
       Ast_52.Outcometree.Otyp_class
         ((copy_out_ident x0), (List.map copy_out_type x1))

--- a/src/vendored-omp/src/migrate_parsetree_52_51_migrate.ml
+++ b/src/vendored-omp/src/migrate_parsetree_52_51_migrate.ml
@@ -170,7 +170,7 @@ and copy_out_class_type :
         ((copy_out_ident x0), (List.map copy_out_type x1))
   | Ast_52.Outcometree.Octy_arrow (x0, x1, x2) ->
       Ast_51.Outcometree.Octy_arrow
-        ((match x0 with Nolabel -> "" | Labelled s | Optional s -> s), (copy_out_type x1), (copy_out_class_type x2))
+        ((match x0 with Nolabel -> "" | Labelled s  -> s | Optional s -> "?" ^ s), (copy_out_type x1), (copy_out_class_type x2))
   | Ast_52.Outcometree.Octy_signature (x0, x1) ->
       Ast_51.Outcometree.Octy_signature
         ((Option.map copy_out_type x0),
@@ -216,7 +216,7 @@ and copy_out_type :
       Ast_51.Outcometree.Otyp_alias {non_gen; aliased=(copy_out_type x0); alias=x1}
   | Ast_52.Outcometree.Otyp_arrow (x0, x1, x2) ->
       Ast_51.Outcometree.Otyp_arrow
-        ((match x0 with Nolabel -> "" | Labelled s | Optional s -> s), (copy_out_type x1), (copy_out_type x2))
+        ((match x0 with Nolabel -> "" | Labelled s -> s | Optional s -> "?" ^ s), (copy_out_type x1), (copy_out_type x2))
   | Ast_52.Outcometree.Otyp_class (x0, x1) ->
       Ast_51.Outcometree.Otyp_class
         ((copy_out_ident x0), (List.map copy_out_type x1))

--- a/test/rtopIntegration.t
+++ b/test/rtopIntegration.t
@@ -14,5 +14,5 @@ into it and asserting the existence of some output.
   $ echo "let f = a => a;" | rtop | grep -o "let f: 'a => 'a = <fun>;"
   let f: 'a => 'a = <fun>;
 
-  $ echo "let f = (a) => 1 + \"hi\";" | rtop | grep -o "This expression has type string but an expression was expected of type"
-  This expression has type string but an expression was expected of type
+  $ echo "let f = (a) => 1 + \"hi\";" | rtop | grep -o "This expression has type"
+  This expression has type


### PR DESCRIPTION
fixes https://github.com/reasonml/reason/issues/2737