### PR TITLE
feat: support `module%ppx` syntax

### DIFF
--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1966,8 +1966,12 @@ signature_item:
   | item_attributes opt_LET_MODULE_REC_ident module_type_body(COLON)
     and_module_rec_declaration*
     { let loc = mklocation $symbolstartpos $endpos($3) in
-      let _ext, letmodule = $2 in
-      Psig_recmodule (Ast_helper.Md.mk letmodule $3 ~attrs:$1 ~loc :: $4) }
+      let ext, letmodule = $2 in
+      wrap_sig_ext
+        ~loc
+        (Psig_recmodule (Ast_helper.Md.mk letmodule $3 ~attrs:$1 ~loc :: $4))
+        ext
+    }
   | item_attributes MODULE TYPE as_loc(ident)
     { let loc = mklocation $symbolstartpos $endpos in
       Psig_modtype (Ast_helper.Mtd.mk $4 ~attrs:$1 ~loc)

--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -1718,8 +1718,11 @@ structure_item:
     | item_attributes opt_LET_MODULE_REC_ident module_binding_body
       and_module_bindings*
       { let loc = mklocation $symbolstartpos $endpos($2) in
-        let _ext, letmodule = $2 in
-        mkstr (Pstr_recmodule ((Ast_helper.Mb.mk letmodule $3 ~attrs:$1 ~loc) :: $4))
+        let ext, letmodule = $2 in
+        wrap_str_ext
+          ~loc
+          (mkstr (Pstr_recmodule ((Ast_helper.Mb.mk letmodule $3 ~attrs:$1 ~loc) :: $4)))
+          ext
       }
     | item_attributes MODULE TYPE OF? as_loc(ident)
       { let loc = mklocation $symbolstartpos $endpos in

--- a/test/general-syntax-rei.t/input.rei
+++ b/test/general-syntax-rei.t/input.rei
@@ -46,3 +46,7 @@ external%foo bar: string => string = "";
 [%%foo: let foo: bar];
 let%foo foo: bar;
 
+module%foo X: Y;
+
+module%foo X = Y;
+

--- a/test/general-syntax-rei.t/input.rei
+++ b/test/general-syntax-rei.t/input.rei
@@ -50,3 +50,5 @@ module%foo X: Y;
 
 module%foo X = Y;
 
+module%foo rec X: Y;
+

--- a/test/general-syntax-rei.t/run.t
+++ b/test/general-syntax-rei.t/run.t
@@ -58,3 +58,5 @@ Format general interface syntax
   module%foo X: Y;
   
   module%foo X = Y;
+  
+  module%foo rec X: Y;

--- a/test/general-syntax-rei.t/run.t
+++ b/test/general-syntax-rei.t/run.t
@@ -54,3 +54,7 @@ Format general interface syntax
   
   let%foo foo: bar;
   let%foo foo: bar;
+  
+  module%foo X: Y;
+  
+  module%foo X = Y;

--- a/test/modules.t/input.re
+++ b/test/modules.t/input.re
@@ -523,3 +523,20 @@ module type TypeWithExternalExtension = {
   external%foo bar: string => string = "";
   [%%foo: external bar: int => int = "hello" ];
 }
+
+module%foo X = Y
+
+module%foo X = {
+  let x = 1;
+};
+
+let x = {
+  let module%foo X = {
+    let x = 1;
+  };
+  ()
+};
+
+module%foo rec X: Y = {
+  let x = 1;
+}

--- a/test/modules.t/run.t
+++ b/test/modules.t/run.t
@@ -689,4 +689,21 @@ Format modules
     external%foo bar: string => string;
     external%foo bar: int => int = "hello";
   };
+  
+  module%foo X = Y;
+  
+  module%foo X = {
+    let x = 1;
+  };
+  
+  let x = {
+    module%foo X = {
+      let x = 1;
+    };
+    ();
+  };
+  
+  module rec X: Y = {
+    let x = 1;
+  };
 /* From http://stackoverflow.com/questions/1986374/  higher-order-type-constructors-and-functors-in-ocaml */

--- a/test/modules.t/run.t
+++ b/test/modules.t/run.t
@@ -703,7 +703,7 @@ Format modules
     ();
   };
   
-  module rec X: Y = {
+  module%foo rec X: Y = {
     let x = 1;
   };
 /* From http://stackoverflow.com/questions/1986374/  higher-order-type-constructors-and-functors-in-ocaml */


### PR DESCRIPTION
fixes #2478

TODO:
- [x] `module%foo rec ..` in structures
- [x] `module%foo rec ..` in signatures
- [x] `let module%foo = .. in ..` expressions