### PR TITLE
always break at `*/` of nonempty doc comments

### DIFF
--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -6660,8 +6660,15 @@ let printer = object(self:'self)
           PStr [{ pstr_desc = Pstr_eval ({ pexp_desc = Pexp_constant (Pconst_string(text, _, None)) } , _);
                   pstr_loc }]
       ; _ } ->
+      let break = if text = "" then Layout.IfNeed else Always_rec in
       let text = if text = "" then "/**/" else "/**" ^ text ^ "*/" in
-      makeList ~inline:(true, true) ~postSpace:true ~preSpace:true ~indent:0 ~break:IfNeed [atom ~loc:pstr_loc text]
+      makeList
+        ~inline:(true, true)
+        ~postSpace:true
+        ~preSpace:true
+        ~indent:0
+        ~break
+        [atom ~loc:pstr_loc text]
     | { attr_name; attr_payload; _ } -> self#payload "@" attr_name attr_payload
 
   (* [@@ ... ] Attributes that occur after a major item in a structure/class *)

--- a/test/4.10/attributes-re.t/run.t
+++ b/test/4.10/attributes-re.t/run.t
@@ -25,7 +25,8 @@ Print the formatted file
   /**removed text on type def*/
   [@itemAttributeOnTypeDef]
   type itemText = int;
-  type nodeText = /**removed text on item*/ int;
+  type nodeText =
+    /**removed text on item*/ int;
   /**removed text on type def*/
   [@itemAttributeOnTypeDef]
   type nodeAndItemText =
@@ -35,7 +36,8 @@ Print the formatted file
   [@itemAttributeOnTypeDef]
   type itemDoc = int;
   [@itemAttributeOnTypeDef]
-  type nodeDoc = /**removed text on item*/ int;
+  type nodeDoc =
+    /**removed text on item*/ int;
   /**removed doc on type def*/
   [@itemAttributeOnTypeDef]
   type nodeAndItemDoc =
@@ -831,8 +833,8 @@ Print the formatted file
 
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
-  File "formatted.re", line 503, characters 4-10:
-  503 |     concat;
+  File "formatted.re", line 505, characters 4-10:
+  505 |     concat;
             ^^^^^^
   Warning 10: this expression should have type unit.
 

--- a/test/4.12/attributes-re.t/run.t
+++ b/test/4.12/attributes-re.t/run.t
@@ -25,7 +25,8 @@ Print the formatted file
   /**removed text on type def*/
   [@itemAttributeOnTypeDef]
   type itemText = int;
-  type nodeText = /**removed text on item*/ int;
+  type nodeText =
+    /**removed text on item*/ int;
   /**removed text on type def*/
   [@itemAttributeOnTypeDef]
   type nodeAndItemText =
@@ -35,7 +36,8 @@ Print the formatted file
   [@itemAttributeOnTypeDef]
   type itemDoc = int;
   [@itemAttributeOnTypeDef]
-  type nodeDoc = /**removed text on item*/ int;
+  type nodeDoc =
+    /**removed text on item*/ int;
   /**removed doc on type def*/
   [@itemAttributeOnTypeDef]
   type nodeAndItemDoc =
@@ -831,8 +833,8 @@ Print the formatted file
 
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
-  File "formatted.re", line 503, characters 4-10:
-  503 |     concat;
+  File "formatted.re", line 505, characters 4-10:
+  505 |     concat;
             ^^^^^^
   Warning 10 [non-unit-statement]: this expression should have type unit.
 

--- a/test/infix.t/run.t
+++ b/test/infix.t/run.t
@@ -591,7 +591,8 @@ Format infix operators
   
       /**
        * Try with ||
-       */ x.contents
+       */
+      x.contents
       || something
       + 1
         ? hello : goodbye;
@@ -619,7 +620,8 @@ Format infix operators
   
       /**
        * Try with &&
-       */ x.contents
+       */
+      x.contents
       && something
       + 1
         ? hello : goodbye;
@@ -739,7 +741,8 @@ Format infix operators
         something
           ? str.[0] = somethingElse : goodbye;
   
-      /** And this */ y :=
+      /** And this */
+      y :=
         something ? y := somethingElse : goodbye;
       arr[0] :=
         something


### PR DESCRIPTION
fixes https://github.com/reasonml/reason/issues/1960