### PR TITLE
fix: parse polyvariants starting with `[|`

### DIFF
--- a/src/reason-parser/reason_parser.mly
+++ b/src/reason-parser/reason_parser.mly
@@ -4646,6 +4646,7 @@ mark_position_typ
     { mktyp(Ptyp_constr($1, [])) }
   | object_record_type
     { $1 }
+  | LBRACKETBAR row_field_list RBRACKET
   | LBRACKET row_field_list RBRACKET
     { mktyp(Ptyp_variant ($2, Closed, None)) }
   | LBRACKETGREATER loption(row_field_list) RBRACKET

--- a/test/variants.t/input.re
+++ b/test/variants.t/input.re
@@ -427,3 +427,11 @@ type widget_state = [
     | `HOVER
     | `ACTIVE
   ];
+
+/* [| purposely without space */
+type apiKeyError = [|`Dev |`Prod];
+
+/* other polyvar variations */
+type apiKeyError = [ | `Dev |`Prod];
+type apiKeyError = [ `Dev |`Prod];
+

--- a/test/variants.t/run.t
+++ b/test/variants.t/run.t
@@ -692,6 +692,22 @@ Format variants
     | `HOVER
     | `ACTIVE
   ];
+  
+  /* [| purposely without space */
+  type apiKeyError = [
+    | `Dev
+    | `Prod
+  ];
+  
+  /* other polyvar variations */
+  type apiKeyError = [
+    | `Dev
+    | `Prod
+  ];
+  type apiKeyError = [
+    | `Dev
+    | `Prod
+  ];
 /* Doesn't work because we've correctly annotated parse tree nodes with   explicit_arity! */
 /* let notTupled: notTupleVariant = NotActuallyATuple intTuple; /*Doesn't work! */  */
 /* Doesn't work because we've correctly annotated parse tree nodes with   explicit_arity! */


### PR DESCRIPTION
fixes https://github.com/reasonml/reason/issues/1994