### PR TITLE
Prepare for 5.2 AST bump

### DIFF
--- a/src/reason-parser/reason_heuristics.ml
+++ b/src/reason-parser/reason_heuristics.ml
@@ -87,7 +87,7 @@ let singleTokenPatternOmmitTrail txt = String.length txt < 4
  *)
 let bsExprCanBeUncurried expr =
   match Parsetree.(expr.pexp_desc) with
-  | Pexp_fun _ | Pexp_apply _ -> true
+  | Pexp_function (_ :: _, _, _) | Pexp_apply _ -> true
   | _ -> false
 
 let isUnderscoreIdent expr =
@@ -107,11 +107,8 @@ let isUnderscoreApplication expr =
   match expr with
   | { pexp_attributes = []
     ; pexp_desc =
-        Pexp_fun
-          ( Nolabel
-          , None
-          , { ppat_desc = Ppat_var { txt = "__x" }; ppat_attributes = [] }
-          , _ )
+        Pexp_function
+          ({ pparam_desc = Pparam_val (Nolabel, None, { ppat_desc = Ppat_var { txt = "__x" }; ppat_attributes = [] }); _ } :: _, _, _)
     } ->
     true
   | _ -> false

--- a/src/reason-parser/reason_syntax_util.cppo.ml
+++ b/src/reason-parser/reason_syntax_util.cppo.ml
@@ -383,8 +383,8 @@ let map_core_type f typ =
         , closed_flag)
     | Ptyp_class (lid, typs) ->
       Ptyp_class (map_lident f lid, typs)
-    | Ptyp_alias (typ, s) ->
-      Ptyp_alias (typ, f s)
+    | Ptyp_alias (typ, lbl) ->
+      Ptyp_alias (typ, { lbl with txt = f lbl.txt })
     | Ptyp_variant (rfs, closed, lbls) ->
       Ptyp_variant (List.map (function
         | { prf_desc = Rtag (lbl, b, cts) } as prf ->
@@ -420,8 +420,13 @@ class identifier_mapper f =
         match expr with
         | { pexp_desc = Pexp_ident lid } ->
           { expr with pexp_desc = Pexp_ident (map_lid lid) }
-        | { pexp_desc = Pexp_fun (label, eo, pat, e) } when !rename_labels ->
-          { expr with pexp_desc = Pexp_fun (map_label label, eo, pat, e) }
+        | { pexp_desc = Pexp_function (params, constraint_, body) } when !rename_labels ->
+          let new_params = List.map (function
+            | { pparam_desc = Pparam_val (lbl, eo, pat); _ } as v ->
+              { v with pparam_desc = Pparam_val (map_label lbl, eo, pat) }
+            | v -> v) params
+          in
+          { expr with pexp_desc = Pexp_function (new_params, constraint_, body) }
         | { pexp_desc = Pexp_apply (e, args) } when !rename_labels ->
           { expr with
             pexp_desc = Pexp_apply (e, List.map (fun (label, e) ->

--- a/test/ocaml_identifiers.t/run.t
+++ b/test/ocaml_identifiers.t/run.t
@@ -113,4 +113,4 @@ Format OCaml identifiers file
       y;
     });
   
-  let newType = (type method, ()) => ();
+  let newType = (type method_, ()) => ();


### PR DESCRIPTION
This PR is a patch for an upcoming release of ppxlib where the internal AST is [bumped from 4.14 to 5.2](https://github.com/ocaml-ppx/ppxlib/pull/514). Until that is merged and released, there is no reason to merge this PR.

Notes for this PR: This PR is an attempt to get the ball rolling. It would need someone more familiar with `reason` to complete the PR and make sure it is working correctly.

To test these changes, you can use the following opam-based workflow. I've made releases of most of these patches to an opam-repository overlay.

```shell
opam switch create ppxlib-bump --repos=ppxlib=git+https://github.com/patricoferris/opam-repository#5.2-ast-bump
opam install <your-package>
```

The following describes the most notable changes to the AST.

Note: no update has been made of the `opam` file, but `ppxlib` will likely need a lower-bound before merging/releasing.

### Functions
---

#### Currently 

In the parsetree currently, functions like:

```ocaml
fun x y z -> ...
```

Are represented roughly as

```ocaml
Pexp_fun(x, Pexp_fun (y, Pexp_fun(z, ...)))
```

Functions like:

```ocaml
function A -> ... | B -> ...
```

Are represented roughly as

```ocaml
Pexp_function ([ case A; case B ])
```

#### Since 5.2

All of these functions now map to a single AST node `Pexp_function` (note, this is the same name as the old cases function). The first argument is a list of parameters meaning:

```ocaml
fun x y z -> ...
```

Now looks like:

```ocaml
Pexp_function([x; y; z], _constraint, body)
```

And the `body` is where we can either have _more_ expressions (`Pfunction_body _`) or cases (`Pfunction_cases _`). That means:

```ocaml
function A -> ... | B -> ...
```

Has an empty list of parameters:

```ocaml
Pexp_function([], _, Pfunction_cases ([case A; case B]))
```

### Local Module Opens for Types

Another feature added in 5.2 was the ability to locally open modules in type definitions. 

```ocaml
module M = struct
  type t = A | B | C
end

type t = Local_open_coming of M.(t)
```

This has a `Ptyp_open (module_identifier, core_type)` AST node. Just like normal module opens this does create some syntactic ambiguity about where things come from inside the parentheses.