### PR TITLE
Fix record field and jsx props punned when with attributes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ _esybuild
 _esyinstall
 _release
 _export/
+
+# opam
+_opam/

--- a/test/jsx.t/input.re
+++ b/test/jsx.t/input.re
@@ -103,6 +103,9 @@ let icon = <Icon
 /* punning for explicitly passed optional */
 <Foo bar=?bar />;
 
+/* Don't pun for explicitly props with attributes */
+<Foo bar=?{[@browser_only]bar} />;
+
 /* don't pun explicitly passed optional with module identifier */
 <Foo bar=?Baz.bar />;
 
@@ -131,6 +134,8 @@ let y = [<Button onClick=handleStaleClick />, <Button onClick=handleStaleClick /
 <Description term=([@JSX] Text.createElement(~text="Age", ()))> child </Description>;
 
 <Description term={<Text superLongPunnedProp anotherSuperLongOneCrazyLongThingHere text="Age" />}> child </Description>;
+<Description term={<Text noPunnedProp={[@attribute] noPunnedProp} superLongPunnedProp anotherSuperLongOneCrazyLongThingHere text="Age" />}> child </Description>;
+<Description term={<Text noPunned={[@attribute] noPunnedProp} />}> child </Description>;
 
 <Foo bar={<Baz superLongPunnedProp anotherSuperLongOneCrazyLongThingHere/>}/>;
 

--- a/test/jsx.t/run.t
+++ b/test/jsx.t/run.t
@@ -140,6 +140,9 @@ Format JSX
   /* punning for explicitly passed optional */
   <Foo ?bar />;
   
+  /* Don't pun for explicitly props with attributes */
+  <Foo bar=?{[@browser_only] bar} />;
+  
   /* don't pun explicitly passed optional with module identifier */
   <Foo bar=?Baz.bar />;
   
@@ -197,6 +200,23 @@ Format JSX
         anotherSuperLongOneCrazyLongThingHere
         text="Age"
       />
+    }>
+    child
+  </Description>;
+  <Description
+    term={
+      <Text
+        noPunnedProp={[@attribute] noPunnedProp}
+        superLongPunnedProp
+        anotherSuperLongOneCrazyLongThingHere
+        text="Age"
+      />
+    }>
+    child
+  </Description>;
+  <Description
+    term={
+      <Text noPunned={[@attribute] noPunnedProp} />
     }>
     child
   </Description>;

--- a/test/sequences.t/input.re
+++ b/test/sequences.t/input.re
@@ -79,3 +79,20 @@ let thirdFieldPunned = {
   c
 };
 let singlePunAcceptedIfExtended = {...firstFieldPunned, a};
+
+/* non-punned */
+let firstFieldNonPun = {
+  a: [@with_attribute] a,
+  b,
+  c
+};
+let secondFieldNonPun = {
+  a,
+  b: [@with_attribute] b,
+  c
+};
+let thirdFieldNonPun = {
+  a,
+  b,
+  c: [@with_attribute] c,
+};

--- a/test/sequences.t/run.t
+++ b/test/sequences.t/run.t
@@ -102,7 +102,23 @@ Print the formatted file
     ...firstFieldPunned,
     a,
   };
-
+  
+  /* non-punned */
+  let firstFieldNonPun = {
+    a: [@with_attribute] a,
+    b,
+    c,
+  };
+  let secondFieldNonPun = {
+    a,
+    b: [@with_attribute] b,
+    c,
+  };
+  let thirdFieldNonPun = {
+    a,
+    b,
+    c: [@with_attribute] c,
+  };
 Type-check basics
   $ ocamlc -c -pp 'refmt --print binary' -intf-suffix .rei -impl formatted.re
 

--- a/test/typeDeclarations.t/input.re
+++ b/test/typeDeclarations.t/input.re
@@ -57,7 +57,15 @@ type foo = option([@foo]string, [@bar](int => string => int));
 /* https://github.com/facebook/reason/issues/2073 */
 type a = array({. "someStringKeyThatCausesLineToBreak": string });
 
+/* Inline type record non punned field */
 type b = {
+  punned: [@with_attribute] punned
+};
+
+/* Breakline record non punned field */
+type c = {
+  a: string,
+  b: string,
   punned: [@with_attribute] punned
 };
 

--- a/test/typeDeclarations.t/run.t
+++ b/test/typeDeclarations.t/run.t
@@ -127,7 +127,15 @@ Format type declarations
       "someStringKeyThatCausesLineToBreak": string,
     });
   
+  /* Inline type record non punned field */
   type b = {punned: [@with_attribute] punned};
+  
+  /* Breakline record non punned field */
+  type c = {
+    a: string,
+    b: string,
+    punned: [@with_attribute] punned,
+  };
   
   type%x foo = int;
   


### PR DESCRIPTION
## Issue #2822 

## Description

This PR adds validation for records fields and jsx props to avoid pun them when the have attributes
