### PR TITLE
ci: test OCaml 5.6

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -28,7 +28,7 @@ jobs:
           - 5_5
           - 5_6
         include:
-          - {ocaml-version: 5_5, os: ubuntu-26.04-arm}
+          - {ocaml-version: 5_6, os: ubuntu-26.04-arm}
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -66,4 +66,3 @@ jobs:
           extra-trusted-public-keys = ocaml.nix-cache.com-1:/xI2h2+56rwFfKyyFVbkJSeGqSIYMC/Je+7XXqGKDIY=
     - name: "Run nix-build"
       run: nix-build ./nix/ci.nix --argstr ocamlVersion ${{ matrix.setup.ocaml-version }}
-

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -28,6 +28,7 @@ jobs:
           - 5_5
           - 5_6
         include:
+          - {ocaml-version: 5_5, os: ubuntu-26.04-arm}
           - {ocaml-version: 5_6, os: ubuntu-26.04-arm}
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/opam-ci.yml
+++ b/.github/workflows/opam-ci.yml
@@ -27,14 +27,17 @@ jobs:
           - {ocaml-compiler: 'ocaml-base-compiler.5.3.0', os: ubuntu-latest}
           - {ocaml-compiler: 'ocaml-base-compiler.5.4.0', os: ubuntu-latest}
           - {ocaml-compiler: 'ocaml-base-compiler.5.5.0', os: ubuntu-latest}
+          - {ocaml-compiler: 'ocaml-variants.5.6.0+trunk', os: ubuntu-latest}
           - {ocaml-compiler: 'ocaml-base-compiler.5.4.0', os: macos-26-intel}
           - {ocaml-compiler: 'ocaml-base-compiler.5.4.0', os: macos-latest}
           - {ocaml-compiler: 'ocaml-base-compiler.5.5.0', os: macos-latest}
+          - {ocaml-compiler: 'ocaml-variants.5.6.0+trunk', os: macos-latest}
             # looks like setup-ocaml@v3 can only run actions on windows for
             # OCaml >= 4.13
             # https://github.com/ocaml/setup-ocaml/issues/822#issuecomment-2215525942
           - {ocaml-compiler: '4.14.x', os: windows-latest}
           - {ocaml-compiler: 'ocaml-base-compiler.5.5.0', os: windows-latest}
+          - {ocaml-compiler: 'ocaml-variants.5.6.0+trunk', os: windows-latest}
 
     runs-on: ${{ matrix.setup.os }}
 

--- a/.github/workflows/opam-ci.yml
+++ b/.github/workflows/opam-ci.yml
@@ -68,6 +68,10 @@ jobs:
           path: _opam
           key: v0.0.1-opam-${{ matrix.setup.os }}-${{ matrix.setup.ocaml-compiler }}-${{ hashFiles('**.opam') }}
 
+      - name: Pin utop for OCaml 5.6
+        if: ${{ matrix.setup.ocaml-compiler == 'ocaml-variants.5.6.0+trunk' }}
+        run: opam pin add utop https://github.com/ocaml-community/utop/archive/64f4486318c128f531f95fddd1f19fa5b0c95191.tar.gz
+
       - name: Install dependencies
         run: opam install . --deps-only
 


### PR DESCRIPTION
Tests OCaml 5.6 trunk in the opam CI matrix and updates the Nix ARM lane. Follows #2935.