### PR TITLE
fix(printer): keep package constraints on the lambda body (#2925)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- fix(printer): keep a package constraint on the lambda body instead of
+  moving it to a return annotation, where it re-parses as an arrow type and
+  changes the meaning of the program (@MavenRain,
+  [#2925](https://github.com/reasonml/reason/issues/2925))
+
 ## 3.18.0
 
 - build: remove unused AST migrations (@anmonteiro,

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -5452,6 +5452,11 @@ let createFormatter () =
              here *)
           let return, optConstr =
             match ret.pexp_desc with
+            (* Keep a package constraint on the body: as a return annotation,
+               `(module Foo)` re-parses as the start of an arrow type, which
+               changes the meaning of the printed code (see #2925). *)
+            | Pexp_constraint (_, { ptyp_desc = Ptyp_package _; _ }) ->
+              ret, None
             | Pexp_constraint (e, ct) -> e, Some (self#non_arrowed_core_type ct)
             | _ -> ret, None
           in
@@ -9753,6 +9758,11 @@ let createFormatter () =
             in
             let retCb, cbArgs =
               match retCb.pexp_desc with
+              (* Keep a package constraint on the body: as a return annotation,
+                 `(module Foo)` re-parses as the start of an arrow type, which
+                 changes the meaning of the printed code (see #2925). *)
+              | Pexp_constraint (_, { ptyp_desc = Ptyp_package _; _ }) ->
+                retCb, cbArgs
               | Pexp_constraint (a, t) ->
                 a, makeList [ cbArgs; atom ": "; self#core_type t ]
               | _ -> retCb, cbArgs

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -737,6 +737,12 @@ let is_simple_construct : construct -> bool = function
   | `nil | `tuple | `list _ | `simple _ | `btrue | `bfalse | `cons _ -> true
   | `normal -> false
 
+(* A package constraint must stay on the lambda body: as a return annotation,
+   `(module Foo)` re-parses as the start of an arrow type, which changes the
+   meaning of the printed code (see #2925). *)
+let is_package_typ ct =
+  match ct.ptyp_desc with Ptyp_package _ -> true | _ -> false
+
 let uncurriedTable = Hashtbl.create 42
 
 (* Determines if a list of expressions contains a single unit construct * e.g.
@@ -5452,12 +5458,8 @@ let createFormatter () =
              here *)
           let return, optConstr =
             match ret.pexp_desc with
-            (* Keep a package constraint on the body: as a return annotation,
-               `(module Foo)` re-parses as the start of an arrow type, which
-               changes the meaning of the printed code (see #2925). *)
-            | Pexp_constraint (_, { ptyp_desc = Ptyp_package _; _ }) ->
-              ret, None
-            | Pexp_constraint (e, ct) -> e, Some (self#non_arrowed_core_type ct)
+            | Pexp_constraint (e, ct) when not (is_package_typ ct) ->
+              e, Some (self#non_arrowed_core_type ct)
             | _ -> ret, None
           in
           let returnExpr, leftWrap =
@@ -9758,12 +9760,7 @@ let createFormatter () =
             in
             let retCb, cbArgs =
               match retCb.pexp_desc with
-              (* Keep a package constraint on the body: as a return annotation,
-                 `(module Foo)` re-parses as the start of an arrow type, which
-                 changes the meaning of the printed code (see #2925). *)
-              | Pexp_constraint (_, { ptyp_desc = Ptyp_package _; _ }) ->
-                retCb, cbArgs
-              | Pexp_constraint (a, t) ->
+              | Pexp_constraint (a, t) when not (is_package_typ t) ->
                 a, makeList [ cbArgs; atom ": "; self#core_type t ]
               | _ -> retCb, cbArgs
             in

--- a/src/reason-parser/reason_pprint_ast.ml
+++ b/src/reason-parser/reason_pprint_ast.ml
@@ -737,9 +737,6 @@ let is_simple_construct : construct -> bool = function
   | `nil | `tuple | `list _ | `simple _ | `btrue | `bfalse | `cons _ -> true
   | `normal -> false
 
-(* A package constraint must stay on the lambda body: as a return annotation,
-   `(module Foo)` re-parses as the start of an arrow type, which changes the
-   meaning of the printed code (see #2925). *)
 let is_package_typ ct =
   match ct.ptyp_desc with Ptyp_package _ -> true | _ -> false
 

--- a/test/firstClassModuleLambda.t/input.re
+++ b/test/firstClassModuleLambda.t/input.re
@@ -1,0 +1,27 @@
+module type FOO = {
+  let foo: string;
+};
+
+module type FOO_WITH_X = {
+  let foo: string;
+  let x: int;
+};
+
+/* A package constraint on a lambda body must stay on the body: hoisted into
+   a return annotation, `(module FOO)` re-parses as the start of an arrow
+   type (issue #2925). */
+let some_foo =
+  some_foo_with_x
+  |> Option.map((module Foo_with_x: FOO_WITH_X) =>
+       (module Foo_with_x: FOO)
+     );
+
+/* Same bug when the lambda is not the last argument. */
+let r = apply((module X: FOO_WITH_X) => ((module X): (module FOO)), 0);
+
+/* Ordinary return types keep the return-annotation form. */
+let s = apply((x: int): int => x + 1, 0);
+
+/* Let bindings keep the return-annotation form: it re-parses correctly
+   there. */
+let f = (module X: FOO_WITH_X): (module FOO) => (module X);

--- a/test/firstClassModuleLambda.t/run.t
+++ b/test/firstClassModuleLambda.t/run.t
@@ -1,0 +1,56 @@
+Format lambdas whose body has a first-class-module package constraint (issue #2925)
+  $ refmt ./input.re > ./formatted.re
+  $ cat ./formatted.re
+  module type FOO = {
+    let foo: string;
+  };
+  
+  module type FOO_WITH_X = {
+    let foo: string;
+    let x: int;
+  };
+  
+  /* A package constraint on a lambda body must stay on the body: hoisted into
+     a return annotation, `(module FOO)` re-parses as the start of an arrow
+     type (issue #2925). */
+  let some_foo =
+    some_foo_with_x
+    |> Option.map((module Foo_with_x: FOO_WITH_X) =>
+         ((module Foo_with_x): (module FOO))
+       );
+  
+  /* Same bug when the lambda is not the last argument. */
+  let r =
+    apply(
+      (module X: FOO_WITH_X) =>
+        ((module X): (module FOO)),
+      0,
+    );
+  
+  /* Ordinary return types keep the return-annotation form. */
+  let s = apply((x: int): int => x + 1, 0);
+  
+  /* Let bindings keep the return-annotation form: it re-parses correctly
+     there. */
+  let f = (module X: FOO_WITH_X): (module FOO) =>
+    (module X);
+
+The formatted output must re-parse with the same meaning: the callbacks stay
+functions instead of collapsing into a constraint with an arrow type
+  $ refmt --parse re --print ml ./formatted.re
+  module type FOO  = sig val foo : string end
+  module type FOO_WITH_X  = sig val foo : string val x : int end
+  let some_foo =
+    some_foo_with_x |>
+      (Option.map
+         (fun ((module Foo_with_x)  : (module FOO_WITH_X)) -> ((module
+            Foo_with_x) : (module FOO))))
+  let r =
+    apply
+      (fun ((module X)  : (module FOO_WITH_X)) -> ((module X) : (module FOO)))
+      0
+  let s = apply (fun (x : int) -> (x + 1 : int)) 0
+  let f ((module X)  : (module FOO_WITH_X)) = ((module X) : (module FOO))
+
+Formatting must be idempotent
+  $ refmt ./formatted.re | diff ./formatted.re -


### PR DESCRIPTION
Fixes #2925.

## Problem

refmt hoists a package constraint on a lambda body into a return annotation. For the program in #2925:

```reason
|> Option.map((module Foo_with_x: FOO_WITH_X) =>
     (module Foo_with_x: FOO)
   );
```

one `refmt` pass produces:

```reason
|> Option.map((module Foo_with_x: FOO_WITH_X): (module FOO) =>
     (module Foo_with_x)
   );
```

That output does not re-parse as a function. After the colon, `(module FOO)` starts an arrow type, so the whole argument re-parses as a constraint expression with the type `(module FOO) => (module Foo_with_x)`. The formatted file no longer compiles, and a second format pass rewrites the line again.

No parenthesization of the return annotation avoids this: `((module FOO))` re-parses the same way. The lexer inserts a speculative `ES6_FUN` token in front of `(module FOO)` because `=>` follows it, and the constraint-expression interpretation wins in the multi-parser whenever the lambda body is itself a valid type, which a package expression always is. So the return-annotation form is not a faithful printing of this AST in expression position, and the printer must not produce it there.

## Fix

Keep a `Ptyp_package` constraint on the body in the two printing paths that serve expression positions:

- `formatPexpFun` (lambdas in argument position and JSX expression containers)
- the trailing-callback path in `formatFunAppl`

The output for the issue example becomes:

```reason
|> Option.map((module Foo_with_x: FOO_WITH_X) =>
     ((module Foo_with_x): (module FOO))
   );
```

which re-parses to the same AST and is stable under repeated formatting.

Let bindings keep the return-annotation form (`let f = (module X: S): (module FOO) => ...`): it re-parses correctly there, so their formatting does not change. Ordinary (non-package) return types are not affected anywhere.

## Testing

New cram test `test/firstClassModuleLambda.t` covers the issue example, a non-trailing callback argument, an ordinary return type, and a let binding. It checks the formatted output, checks that it re-parses with the same meaning via `--parse re --print ml`, and checks idempotency. The `--print ml` output of the formatted issue example compiles with ocamlc. All 77 non-rtop cram tests pass.
